### PR TITLE
Renamed the CSS-class postlist-wrapper to table-listing

### DIFF
--- a/admin/postlist.php
+++ b/admin/postlist.php
@@ -12,7 +12,7 @@
 *******************************************************************************/
 
     $feedbackMessage = NULL;
-    $draftMessage = "<p class=\"postlist-wrapper__draft-info\">Det här inlägget är inte publicerat</p>";
+    $draftMessage = "<p class=\"table-listing__draft-info\">Det här inlägget är inte publicerat</p>";
 
     if (isset($_POST["edit-post"])) {
         $postToEdit = $_POST["edit-post"];
@@ -56,14 +56,14 @@
 <main class="dark">
     <h2>Inlägg</h2>
     <form method="POST" action="./postlist.php">
-        <table>
+        <table class="table-listing">
             <thead class="hidden">
                 <td>Foto</td>
                 <td>Rubrik</td>
                 <td>Redigera</td>
                 <td>Ta bort</td>
             </thead>
-            <tbody class="postlist-wrapper">
+            <tbody>
                 <?php while (mysqli_stmt_fetch($stmt)):
 
                     $draft = FALSE;
@@ -72,18 +72,18 @@
                         $modifier = "grayscale";
                     }
                 ?>
-                <tr class="postlist-wrapper__row">
-                    <td class="postlist-wrapper__td">
-                        <img src="../<?php echo $image; ?>" alt="Image of cats and space" class="postlist-wrapper__img <?php if ($draft) { echo $modifier; } ?>">
+                <tr class="table-listing__row">
+                    <td class="table-listing__td">
+                        <img src="../<?php echo $image; ?>" alt="Image of cats and space" class="table-listing__img <?php if ($draft) { echo $modifier; } ?>">
                         <?php if ($draft) { echo $draftMessage; } ?>
                     </td>
-                    <td class="postlist-wrapper__td">
-                        <h3 class="postlist-wrapper__title"><?php echo $title; ?></h3>
+                    <td class="table-listing__td">
+                        <h3 class="table-listing__title"><?php echo $title; ?></h3>
                     </td>
-                    <td class="postlist-wrapper__td">
+                    <td class="table-listing__td">
                         <button type="submit" class="button" name="edit-post" value="<?php echo $id; ?>">Redigera</button>
                     </td>
-                    <td class="postlist-wrapper__td">
+                    <td class="table-listing__td">
                         <button type="submit" class="button error" name="delete-post" value="<?php echo $id; ?>">Ta bort</button>
                     </td>
                 </tr>

--- a/styles/scss/_tablelisting.scss
+++ b/styles/scss/_tablelisting.scss
@@ -1,16 +1,16 @@
-.postlist-wrapper__img {
+.table-listing__img {
     box-sizing: border-box;
     width: 100%;
 }
 
-.postlist-wrapper__row {
+.table-listing__row {
     display: flex;
     flex-direction: column;
     margin: 1.5em 0;
     padding-bottom: 1em;
 }
 
-.postlist-wrapper__draft-info {
+.table-listing__draft-info {
     background-color: $complimentary;
     box-sizing: border-box;
     box-shadow: 1px 2px 2px rgba(0, 0, 0, 0.2);
@@ -22,11 +22,11 @@
     top: 1.5rem;
 }
 
-.postlist-wrapper__td {
+.table-listing__td {
     position: relative;
 }
 
-.postlist-wrapper__title {
+.table-listing__title {
     color: $baseColor2;
     position: absolute;
     bottom: 20px;

--- a/styles/scss/main.scss
+++ b/styles/scss/main.scss
@@ -9,7 +9,7 @@
 @import "alerts";
 @import "utilities";
 @import "comments";
-@import "postlist";
+@import "tablelisting";
 
 
 


### PR DESCRIPTION
# Edited:
**admin/postlist.php** <- Changed name on classes, from
“postlist-wrapper” to “table-listing”. The name is not optimal, but I
would like to avoid confusion that this file is only applied to
postlist.php. It could be used in many other places where there is a
table that wraps around a list of elements.

**styles/scss/_postlist.scss, styles/scss/main.scss** <- Renaming!