### PR TITLE
Feature/mobile first

### DIFF
--- a/styles/scss/_base.scss
+++ b/styles/scss/_base.scss
@@ -23,20 +23,20 @@ main {
 }
 
 header {
-    animation-name: menu-is-sliding-in;
-    animation-duration: 1.2s;
-    animation-delay: 0.2s;
-    animation-iteration-count: 1;
-    animation-fill-mode: forwards;
+    // animation-name: menu-is-sliding-in;
+    // animation-duration: 1.2s;
+    // animation-delay: 0.2s;
+    // animation-iteration-count: 1;
+    // animation-fill-mode: forwards;
     background-color: $baseColorSemiTransparent;
     box-sizing: border-box;
     box-shadow: 1px 2px 2px rgba(0, 0, 0, 0.2);
     color: $baseColor2;
-    display: flex;
-    justify-content: space-between;
+    @include flexbox();
+    @include flexboxJustifyContent(space-between);
     padding: 0.8rem 2rem;
     position: fixed;
-    top: -6.8rem;
+    //top: -6.8rem;
     width: 100%;
     z-index: 2;
     -webkit-backdrop-filter: blur(5px);
@@ -46,6 +46,9 @@ header {
 .logo {
     height: 3em;
     width: 3em;
+    @include mobile-s {
+        display: none;
+    }
 }
 
 /*******************************************************************************

--- a/styles/scss/_bloglist.scss
+++ b/styles/scss/_bloglist.scss
@@ -45,7 +45,11 @@
     color: $primary;
     font-size: 1.8rem;
     font-family: $primaryBrandFont;
-    //margin-bottom: 0.4em;
+
+    @include mobile-s {
+        font-size: 1.5rem;
+    }
+    
     a {
         color: $primary;
     }

--- a/styles/scss/_bloglist.scss
+++ b/styles/scss/_bloglist.scss
@@ -29,7 +29,7 @@
     display: block;
     left: 0;
     position: relative;
-    padding: 1em 0.7em 1.5em;
+    padding: 1em 0.7em 0;
     width: 100%;
 }
 
@@ -43,7 +43,7 @@
     margin: 0.2em 0;
     line-height: 1.3em;
     color: $primary;
-    font-size: 2.5rem;
+    font-size: 1.8rem;
     font-family: $primaryBrandFont;
     //margin-bottom: 0.4em;
     a {

--- a/styles/scss/_comments.scss
+++ b/styles/scss/_comments.scss
@@ -13,7 +13,7 @@
     font-family: $primaryBrandFont;
     font-size: 2.4rem;
     font-weight: 600;
-    right: 1.9rem;
+    right: 2rem;
     position: absolute;
     top: 0.5rem;
     text-align: center;

--- a/styles/scss/_comments.scss
+++ b/styles/scss/_comments.scss
@@ -4,8 +4,8 @@
     //float: right;
     position: relative;
     cursor: pointer;
-    display: flex;
-    justify-content: flex-end;
+    @include flexbox();
+    @include flexboxJustifyContent(flex-end)
 }
 
 .comment-bubble__number {

--- a/styles/scss/_mixins.scss
+++ b/styles/scss/_mixins.scss
@@ -8,6 +8,19 @@
     width: 1px;
 }
 
+@mixin flexbox() {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+}
+
+@mixin flexboxJustifyContent($value) {
+    -webkit-justify-content: $value;
+    justify-content: $value;
+}
+
 
 /*******************************************************************************
     MEDIA QUERIES / RESPONSIVE DESIGN
@@ -15,37 +28,29 @@
 *******************************************************************************/
 // TODO: Clean up comments.
 
-@mixin mobile {
-@media (max-width: #{$tablet-width - 1px}) {
-  @content;
-}
+@mixin mobile-s {
+    @media (max-width: #{$mobile-m-width - 1px}) {
+        @content;
+    }
 }
 
-/* Compiles to: */
-
-// @media (max-width: 767px) {}
+@mixin mobile-m {
+    @media (min-width: #{$mobile-m-width}) and (max-width: #{$tablet-width - 1px}) {
+        @content;
+    }
+}
 
 @mixin tablet {
-  @media (min-width: #{$tablet-width}) and (max-width: #{$desktop-width - 1px}) {
-    @content;
-  }
+    @media (min-width: #{$tablet-width}) and (max-width: #{$desktop-width - 1px}) {
+        @content;
+    }
 }
-
-/* Compiles to: */
-
-// @media (min-width: 768px) and (max-width: 1023px) {}
-
 
 @mixin desktop {
-  @media (min-width: #{$desktop-width}) {
-    @content;
-  }
+    @media (min-width: #{$desktop-width}) {
+        @content;
+    }
 }
-
-/* Compiles to: */
-
-// @media (min-width: 1024px) {}
-
 
 /* Use it like this: */
 

--- a/styles/scss/_typography.scss
+++ b/styles/scss/_typography.scss
@@ -16,7 +16,7 @@ body {
 h1, h2, h3 {
     font-family: $primaryBrandFont;
     font-weight: $primaryBrandWeight;
-    font-size: 4rem;
+    font-size: 3rem;
     margin: 0;
     padding-top: 0.3rem;
     text-align: left;
@@ -30,10 +30,22 @@ h2 {
 .logo-title {
     font-family: $primaryBrandFont;
     font-weight: $primaryBrandWeight;
-    font-size: 4rem;
+    font-size: 3rem;
     margin: 0;
-    padding-top: 0.3rem;
+    padding-top: 0.8rem;
     text-align: center;
+
+    @include tablet {
+        font-size: 4rem;
+        margin: 0;
+        padding-top: 0.3rem;
+    }
+
+    @include desktop {
+        font-size: 4rem;
+        margin: 0;
+        padding-top: 0.3rem;
+    }
 }
 
 a {

--- a/styles/scss/_variables.scss
+++ b/styles/scss/_variables.scss
@@ -17,5 +17,6 @@ $primaryBrandWeight: 400;
 $secondaryBrandFont: 'Montserrat', sans-serif;
 
 // Media queries
+$mobile-m-width: 480px;
 $tablet-width: 768px;
 $desktop-width: 1024px;


### PR DESCRIPTION
# Edited:

**styles/scss/_mixins.scss**
- Added flexbox mixin (w. webkit -moz- -ms-)
_instead of `display: flex;` use `@include flexbox();`

- Added justify content mixin.
_instead of `justify-content: value;` use `@include flexboxJustifyContent(value);`_

- Added two mobile sizes `@mixin mobile-s` `@mixin mobile-m`

**styles/scss/_base.scss**
- Commented out header animation property because of compatibility issues.
- Now using flexbox mixin instead of old property.
- Logo is now hidden when using smallest device size (mobile-s)

**styles/scss/_bloglist.scss**
- Smaller font-size removed padding (mobile first)

**styles/scss/_comments.scss**
- Flexbox mixin instead of old property.

**styles/scss/_typography.scss**
- Smaller font-size (mobile first)
- Added `@include tablet` + `@include desktop` for testing.

**styles/scss/_variables.scss**
- New mobile-width `$mobile-m-width: 480px;` // TODO: change variables -> codestyling guide standard

# Tested:
## Iphone 4
### 320 × 480
![Image of iphone 4](http://www.hkrei.se/img/iphone4.jpeg)
## Sony Xperia Z3+
### 360 × 640
![Image of xperia](http://www.hkrei.se/img/sony_xperia.png)